### PR TITLE
Adding option to avoid printing table

### DIFF
--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -14,14 +14,14 @@ Arguments:
   azk_bin_path            Full path of azk binary/link [default: azk].
 
 Options:
-  -h --help               Show this help.
-  --version               Show version.
+  --send                  Send results to Keen.IO
+  --plain                 Suppress stylized table from output
   --git-repo=<git-repo>   Github URL to clone and start
   --dest-path=<dest-path> Override destination path when cloning
   --git-ref=<git-ref>     Git branch, tag or commit to clone
-  --send                  Send results to Keen.IO
+  --version               Show version.
   --no-color              Remove colors from output
-  --plain                 Suppress stylized table from output
+  --help, -h              Show this help.
   --verbose, -v           Sets the level of detail - multiple supported (-vv)
 
 Examples:

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -6,7 +6,7 @@
   - You should tell where does azk binary is.
 
 Usage:
-  azk-benchmark [<azk_bin_path>] [--git-repo=<git-repo> --dest-path=<dest-path> --git-ref=<git-ref> --send] [--no-color] [-v]...
+  azk-benchmark [<azk_bin_path>] [--git-repo=<git-repo> --dest-path=<dest-path> --git-ref=<git-ref> --send] [--no-color] [--plain] [-v]...
   azk-benchmark -h | --help
   azk-benchmark --version
 
@@ -21,6 +21,7 @@ Options:
   --git-ref=<git-ref>     Git branch, tag or commit to clone
   --send                  Send results to Keen.IO
   --no-color              Remove colors from output
+  --plain                 Suppress stylized table from output
   --verbose, -v           Sets the level of detail - multiple supported (-vv)
 
 Examples:

--- a/spec/utils/which_helper_spec.js
+++ b/spec/utils/which_helper_spec.js
@@ -8,7 +8,7 @@ describe('whichHelper:', () => {
   });
 
   it("should whichHelper reject when not find the command", () => {
-    return h.expect(whichHelper('NOT-EXISTING-PATH')).eventually.be.rejected;
+    return h.expect(whichHelper('NOT-EXISTING-PATH')).eventually.to.rejected;
   });
 
 });

--- a/src/benchmark/azk_benchmark.js
+++ b/src/benchmark/azk_benchmark.js
@@ -55,8 +55,9 @@ export default class AzkBenchmark {
     .then(this._runMainActions.bind(this))
     .then(this._processResults.bind(this))
     .catch((err) => {
-      console.error(err);
-      return 1;
+      const newError = new Error(err.message);
+      newError.code = err.code;
+      throw newError;
     });
   }
 
@@ -79,10 +80,6 @@ export default class AzkBenchmark {
           process.stdout.write(' ' + chalk.green(result_to_send.time.toString() + 'ms') + '\n\n');
         }
         return result_to_send;
-      })
-      .catch((err) => {
-        console.error(err);
-        console.error(params_result);
       });
     });
   }

--- a/src/benchmark/azk_benchmark.js
+++ b/src/benchmark/azk_benchmark.js
@@ -135,9 +135,17 @@ export default class AzkBenchmark {
   }
 
   _processResults(final_results) {
-    var table = new Table({
+    let table_args = (this.opts.plain) ? {
+      chars: { 'top': '' , 'top-mid': '' , 'top-left': '' , 'top-right': '',
+       'bottom': '' , 'bottom-mid': '' , 'bottom-left': '' , 'bottom-right': '',
+       'left': '' , 'left-mid': '' , 'mid': '' , 'mid-mid': '',
+       'right': '' , 'right-mid': '' , 'middle': ' ' },
+      style: { 'padding-left': 0, 'padding-right': 0 }
+    } : {
       style: {head: ['white'], border: ['grey']}
-    });
+    };
+
+    var table = new Table(table_args);
 
     // each result
     final_results.forEach((item) => {
@@ -179,7 +187,7 @@ export default class AzkBenchmark {
         }
       });
     } else {
-      console.log(chalk.green('Benchmark finished. No data was sent.'));
+      console.error(chalk.green('Benchmark finished. No data was sent.'));
       return 0;
     }
   }

--- a/src/cli/controllers/start.js
+++ b/src/cli/controllers/start.js
@@ -16,6 +16,7 @@ class Version extends CliController {
         dest_path: params['dest-path'] || '/tmp/azkdemo_benchmark',
         git_ref: params['git-ref']     || 'benchmark',
         send: params.send,
+        plain: params.plain,
         verbose_level: params.verbose,
         projectId: process.env.AZK_BENCHMARK_KEEN_IO_PROJECTID ||
           '5526968d672e6c5a0d0ebec6',
@@ -27,7 +28,7 @@ class Version extends CliController {
       });
 
       if (params.verbose === 0) {
-        console.log('benchmarking... (this may take a while)');
+        console.error('Benchmarking... (this may take a while)');
       } else if (params.verbose > 0) {
         // show options
         console.log(chalk.blue(' -----------------------------------'));

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -18,8 +18,9 @@ module.exports = class AzkBenchmarkCli {
       return result
       .then((promise_result) => process.exit(promise_result))
       .catch((err) => {
-        console.error(chalk.red(err.stack ? err.stack : err.toString()));
-        process.exit(1);
+        console.error(chalk.bold.red('\n\nError has occurred. Stoping execution.\n'));
+        console.error(chalk.red(err.stack));
+        process.exit(err.code);
       });
     } else {
       // no promise

--- a/src/utils/which_helper.js
+++ b/src/utils/which_helper.js
@@ -7,7 +7,6 @@ let whichHelper = (command_path) => {
       if (err) {
         // err is returned if no "command_path" is found on the PATH
         err = new Error(`'${command_path}' not found in PATH: ${process.env.PATH}. Original error: ${err.message}`);
-        throw err;
         reject(err);
       } else {
         // if it is found, then the absolute path to the exec is returned

--- a/src/utils/which_helper.js
+++ b/src/utils/which_helper.js
@@ -5,9 +5,9 @@ let whichHelper = (command_path) => {
   return new BB.Promise((resolve, reject) => {
     which(command_path, (err, resolvedPath) => {
       if (err) {
-        // er is returned if no "command_path" is found on the PATH
-        err = new Error(`'${command_path}' not found in PATH: ${process.env.PATH}`);
-        err.stack = undefined;
+        // err is returned if no "command_path" is found on the PATH
+        err = new Error(`'${command_path}' not found in PATH: ${process.env.PATH}. Original error: ${err.message}`);
+        throw err;
         reject(err);
       } else {
         // if it is found, then the absolute path to the exec is returned


### PR DESCRIPTION
This PR adds `--plain` option, forcing the output be a simple straightforward text:

``` sh
Benchmark Results:
azk agent start --no-color       5720 
azk version --no-color           2238 
azk docker --no-color -- version 2222 
azk docker --no-color -- info    2610 
azk info --no-color              2407 
azk start --no-color             8318 
azk status --no-color            2314 
azk stop --no-color              7600 
azk agent stop --no-color        4196 
total                            37625
```

Plus, some `console.log` were converted into more appropriated `console.error`
